### PR TITLE
Preparación para la revisión oficial y corrección de fallos

### DIFF
--- a/addon/globalPlugins/WikiChecker/__init__.py
+++ b/addon/globalPlugins/WikiChecker/__init__.py
@@ -28,8 +28,10 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			return
 
 		self.mainWindow = MainWindow(gui.mainFrame, _("WikiChecker - Ventana Principal"))
-
+		if hasattr(globalVars, 'wikiChecker'):
+			self.postStartupHandler()
 		core.postNvdaStartup.register(self.postStartupHandler)
+		globalVars.wikiChecker = None
 
 	@script(gesture=None, description=_("Busca los artículos relacionados con el término introducido en Wikipedia."), category=_("WikiChecker"))
 	def script_checkWikiTerm(self, gesture):

--- a/addon/globalPlugins/WikiChecker/__init__.py
+++ b/addon/globalPlugins/WikiChecker/__init__.py
@@ -35,6 +35,8 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
 	@script(gesture=None, description=_("Busca los artículos relacionados con el término introducido en Wikipedia."), category=_("WikiChecker"))
 	def script_checkWikiTerm(self, gesture):
+		if len(self.mainWindow.languages)==0:
+			self.mainWindow.loadLanguagesList()
 		if not self.mainWindow.IsShown():
 			gui.mainFrame.prePopup()
 			self.mainWindow.Show()

--- a/addon/globalPlugins/WikiChecker/controller.py
+++ b/addon/globalPlugins/WikiChecker/controller.py
@@ -11,7 +11,7 @@ import wx
 import languageHandler
 import addonHandler
 import gui
-
+from logHandler import log
 # We define the path where the bs4 module and the like should be searched.
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
@@ -59,7 +59,7 @@ class DoLanguageCheck(Thread):
 		try:
 			html = request.urlopen(req)
 		except:
-			wx.CallAfter(gui.messageBox, _("No se ha podido recuperar la lista de idiomas de Wikipedia."), _("¡Error!"), wx.ICON_ERROR)
+			log.error("No se ha podido cargar la lista de idiomas de Wikipedia")
 			return
 
 		try:
@@ -76,7 +76,7 @@ class DoLanguageCheck(Thread):
 
 			wx.CallAfter(setDefaultLanguage, self.parent)
 		except:
-			wx.CallAfter(gui.messageBox, _("Imposible recuperar el listado de idiomas de Wikipedia."), _("¡Error!"), wx.ICON_ERROR)
+			log.error("Imposible recuperar el listado de idiomas de Wikipedia.")
 			return
 
 # Remove the HTML tags from the text passed as an argument.

--- a/addon/globalPlugins/WikiChecker/view.py
+++ b/addon/globalPlugins/WikiChecker/view.py
@@ -49,7 +49,7 @@ class MainWindow(wx.Dialog):
 
 	# We control the different events that occur.
 	def onKeyEvent(self, event):
-		if event.GetUnicodeKey() == wx.WXK_RETURN:
+		if event.GetUnicodeKey() in [wx.WXK_RETURN, wx.WXK_NUMPAD_ENTER]:
 			focus = wx.Window.FindFocus().GetId()
 			if focus == 101:
 				if self.searchTermCtrl.GetValue() == "":


### PR DESCRIPTION
Estos son los cambios que te he hecho:

* Si no se puede cargar la lista de idiomas, se registra un error en el log en lugar de notificarlo al usuario.
* El complemento vuelve a comportarse adecuadamente tras recargar los plugins. Para ello, se almacena una variable en el módulo globalVars, cuya presencia indica si debemos llamar a postStartupHandler a mano o no.
* Al pulsar el gesto asociado al complemento, si la lista de idiomas está vacía, se invoca al hilo encargado de rellenarla.
* Ahora, se tienen en cuenta las pulsaciones de la tecla intro del bloque numérico (wx.WXK_NUMPAD_ENTER). Algunos usuarios, especialmente los que todavía no conocen bien el teclado, la usan con más frecuencia, y quizá sea por ahí por donde te han venido las quejas. Por lo tanto, la evaluación de la tecla queda así: if event.GetUnicodeKey() in [wx.WXK_RETURN, wx.WXK_NUMPAD_ENTER]

Antes de liberar una nueva release, queda una tarea que ya te dejo a ti. Igual que compruebas que el cuadro de texto no esté vacío, comprueba que el cuadro combinado de idioma tiene algo seleccionado. Si no es así, lanza un mensaje de error al usuario pidiendo que seleccione un idioma, que compruebe su conexión a Internet y que reinicie NVDA si no ve nada para seleccionar.
Pongo en copia a @hxebolax y @javidominguez para que participen si lo consideran oportuno.