### PR TITLE
Cambiado sizer a VERTICAL y añadido control de ejecución de dialogo wx

### DIFF
--- a/addon/globalPlugins/WikiChecker/__init__.py
+++ b/addon/globalPlugins/WikiChecker/__init__.py
@@ -13,7 +13,7 @@ import globalVars
 import config
 import core
 import addonHandler
-
+import ui
 from scriptHandler import script
 
 from .view import *
@@ -37,14 +37,21 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 	def script_checkWikiTerm(self, gesture):
 		if len(self.mainWindow.languages)==0:
 			self.mainWindow.loadLanguagesList()
-		if not self.mainWindow.IsShown():
-			gui.mainFrame.prePopup()
-			self.mainWindow.Show()
-			self.mainWindow.searchTermCtrl.SetFocus()
-			self.mainWindow.resultsList.Enabled = False
-			self.mainWindow.resultsList.SetItems([])
-			self.mainWindow.CenterOnScreen()
-			gui.mainFrame.postPopup()
+		if self.mainWindow.okLanguages:
+			if not self.mainWindow.IsShown():
+				gui.mainFrame.prePopup()
+				self.mainWindow.Show()
+				self.mainWindow.searchTermCtrl.SetFocus()
+				self.mainWindow.resultsList.Enabled = False
+				self.mainWindow.resultsList.SetItems([])
+				self.mainWindow.CenterOnScreen()
+				gui.mainFrame.postPopup()
+		else:
+			msg = \
+_("""No se pudieron cargar los idiomas del complemento. Vuelve a intentarlo en unos segundos.
+
+Si el problema persiste comprueba tu conexión a Internet, o reinicia NVDA.""")
+			ui.message(msg)
 
 	def postStartupHandler(self):
 		self.mainWindow.loadLanguagesList()

--- a/addon/globalPlugins/WikiChecker/controller.py
+++ b/addon/globalPlugins/WikiChecker/controller.py
@@ -59,6 +59,7 @@ class DoLanguageCheck(Thread):
 		try:
 			html = request.urlopen(req)
 		except:
+			self.parent.okLanguages = False
 			log.error("No se ha podido cargar la lista de idiomas de Wikipedia")
 			return
 
@@ -74,8 +75,10 @@ class DoLanguageCheck(Thread):
 				self.parent.languages.append(abbreviation)
 				self.parent.languagesList.Append(name)
 
+			self.parent.okLanguages = True
 			wx.CallAfter(setDefaultLanguage, self.parent)
 		except:
+			self.parent.okLanguages = False
 			log.error("Imposible recuperar el listado de idiomas de Wikipedia.")
 			return
 

--- a/addon/globalPlugins/WikiChecker/view.py
+++ b/addon/globalPlugins/WikiChecker/view.py
@@ -19,10 +19,11 @@ class MainWindow(wx.Dialog):
 		super(MainWindow, self).__init__(parent, -1, title, size=(1000,700))
 		self.results = []
 		self.languages = []
+		self.okLanguages = False
 
 		self.panel = wx.Panel(self, wx.ID_ANY)
 
-		sizer = wx.BoxSizer(wx.HORIZONTAL)
+		sizer = wx.BoxSizer(wx.VERTICAL)
 
 		self.availableLanguagesLbl = wx.StaticText(self.panel, wx.ID_ANY, _("&Idiomas disponibles"))
 


### PR DESCRIPTION
E cambiado el sizer del dialogo del complemento a VERTICAL ya que así su visualización es correcta y no queda todo tan junto.

E añadido en __init__ un if el cual comprobara si hay lenguajes, si hay lanzara el dialogo.

Si no hay nos informara con instrucciones.

Dicho if comprobara una bandera en el dialogo MainWindow si el hilo que obtiene los lenguajes cambia a True la bandera nos mostrara el dialogo.

Si el hilo que obtiene los lenguajes no consigue obtenerlos la bandera continuara en False y no mostrara el dialogo.

Considero que mostrar el dialogo sin poder ser usado por que no se pudieron obtener los idiomas no es correcto.

Espero haberlo echo bien pero me suena que la cague.

@javidominguez y @jmdaweb
