### PR TITLE
Quitados los espacios del principio de los idiomas

### DIFF
--- a/addon/globalPlugins/WikiChecker/controller.py
+++ b/addon/globalPlugins/WikiChecker/controller.py
@@ -72,8 +72,8 @@ class DoLanguageCheck(Thread):
 
 			for i in range(1, len(rows)):
 				cells = rows[i].find_all('td')
-				abbreviation = cells[0].a.string
-				name = cells[1].a.string
+				abbreviation = cells[0].a.string.strip()
+				name = cells[1].a.string.strip()
 				self.parent.languages.append(abbreviation)
 				self.parent.languagesList.Append(name)
 


### PR DESCRIPTION
Esto hacía que algunos idiomas como el retorrumano se pudieran acceder utilizando el espacio como primer carácter.
Esto es, yendo al cuadro combinado de los idiomas y pulsando espacio en lugar de r.
